### PR TITLE
Nixify using `haskell-flake`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 dist/
+dist-newstyle
 .cabal-sandbox/
 cabal.sandbox.config
 cabal.config
 /.stack-work
+
+# Nix
+result

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,5 @@
+packages:
+  prometheus-client
+  prometheus-metrics-ghc
+  prometheus-proc
+  wai-middleware-prometheus

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1675933616,
-        "narHash": "sha256-/rczJkJHtx16IFxMmAWu5nNYcSXNg1YYXTHoGjLrLUA=",
+        "lastModified": 1683560683,
+        "narHash": "sha256-XAygPMN5Xnk/W2c1aW0jyEa6lfMDZWlQgiNtmHXytPc=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "47478a4a003e745402acf63be7f9a092d51b83d7",
+        "rev": "006c75898cf814ef9497252b022e91c946ba8e17",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "haskell-flake": {
       "locked": {
-        "lastModified": 1676149835,
-        "narHash": "sha256-rE/MIjs65pBtYzpyltvoZx4V8GcGkuh04GjlLi4VvTE=",
+        "lastModified": 1683641774,
+        "narHash": "sha256-6clCN5n/qd5/hk/f+M+4sr1VVs/sEgwH+sgE7PkKQOc=",
         "owner": "srid",
         "repo": "haskell-flake",
-        "rev": "34641d4508c2ad00d1a5ef5fb592f49bfa9e2770",
+        "rev": "ebfe70269fce376a7c95d6e9f011e16cbfd29b8d",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1676150441,
-        "narHash": "sha256-Nfeua9Ua/dGHOQpzOjLtkyMyW/ysQCvZJ9Dd74QQSNk=",
+        "lastModified": 1683657389,
+        "narHash": "sha256-jx91UqqoBneE8QPAKJA29GANrU/Z7ULghoa/JE0+Edw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6d87734c880d704f6ee13e5c0fe835b98918c34e",
+        "rev": "9524f57dd5b3944c819dd594aed8ed941932ef56",
         "type": "github"
       },
       "original": {
@@ -52,11 +52,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1675183161,
-        "narHash": "sha256-Zq8sNgAxDckpn7tJo7V1afRSk2eoVbu3OjI1QklGLNg=",
+        "lastModified": 1682879489,
+        "narHash": "sha256-sASwo8gBt7JDnOOstnps90K1wxmVfyhsTPPNTGBPjjg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e1e1b192c1a5aab2960bf0a0bd53a2e8124fa18e",
+        "rev": "da45bf6ec7bbcc5d1e14d3795c025199f28e0de0",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,80 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1675933616,
+        "narHash": "sha256-/rczJkJHtx16IFxMmAWu5nNYcSXNg1YYXTHoGjLrLUA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "47478a4a003e745402acf63be7f9a092d51b83d7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "haskell-flake": {
+      "locked": {
+        "lastModified": 1676149835,
+        "narHash": "sha256-rE/MIjs65pBtYzpyltvoZx4V8GcGkuh04GjlLi4VvTE=",
+        "owner": "srid",
+        "repo": "haskell-flake",
+        "rev": "34641d4508c2ad00d1a5ef5fb592f49bfa9e2770",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "haskell-flake",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1676150441,
+        "narHash": "sha256-Nfeua9Ua/dGHOQpzOjLtkyMyW/ysQCvZJ9Dd74QQSNk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "6d87734c880d704f6ee13e5c0fe835b98918c34e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1675183161,
+        "narHash": "sha256-Zq8sNgAxDckpn7tJo7V1afRSk2eoVbu3OjI1QklGLNg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e1e1b192c1a5aab2960bf0a0bd53a2e8124fa18e",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "haskell-flake": "haskell-flake",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -5,39 +5,13 @@
     haskell-flake.url = "github:srid/haskell-flake";
   };
   outputs = inputs@{ self, nixpkgs, flake-parts, ... }:
-    flake-parts.lib.mkFlake { inherit inputs; } ({ withSystem, ... }: {
+    flake-parts.lib.mkFlake { inherit inputs; } {
       systems = nixpkgs.lib.systems.flakeExposed;
       imports = [
         inputs.haskell-flake.flakeModule
       ];
       perSystem = { self', pkgs, ... }: {
-        haskellProjects.default = {
-          imports = [
-            self.haskellFlakeProjectModules.input
-          ];
-        };
+        haskellProjects.default = { };
       };
-      # TODO: Generalize and move to a new flake-parts module (or haskell-flake)
-      flake.haskellFlakeProjectModules = rec {
-        # Overlay consumed by this flake.
-        input = { pkgs, ... }: {
-          imports = [
-            # Flake input dependencies go here.
-          ];
-          # Haskell overrides go here.
-          overrides = self: super: { };
-        };
-        # Overlay exposed by this flake.
-        output = { pkgs, lib, ... }: withSystem pkgs.system (ctx@{ config, ... }: {
-          # Pass along the dependency overrides to consuming flake.
-          imports = [
-            input
-          ];
-          # Pass local packages, as overlay, to the consuming flake.
-          source-overrides =
-            lib.mapAttrs (name: ks: ks.root)
-              config.haskellProjects.default.packages;
-        });
-      };
-    });
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,11 @@
         inputs.haskell-flake.flakeModule
       ];
       perSystem = { self', pkgs, ... }: {
-        haskellProjects.default = { };
+        haskellProjects.default = {
+          imports = [
+            self.haskellFlakeProjectModules.input
+          ];
+        };
       };
       # TODO: Generalize and move to a new flake-parts module (or haskell-flake)
       flake.haskellFlakeProjectModules = rec {

--- a/flake.nix
+++ b/flake.nix
@@ -5,22 +5,18 @@
     haskell-flake.url = "github:srid/haskell-flake";
   };
   outputs = inputs@{ self, nixpkgs, flake-parts, ... }:
-    flake-parts.lib.mkFlake { inherit inputs; } {
       systems = nixpkgs.lib.systems.flakeExposed;
+    flake-parts.lib.mkFlake { inherit inputs; } ({ withSystem, ... }: {
       imports = [
         inputs.haskell-flake.flakeModule
       ];
       perSystem = { self', pkgs, ... }: {
         haskellProjects.default = { };
       };
-      flake.haskellFlakeProjectModules.output = { pkgs, ... }: {
-        source-overrides = {
-          prometheus-client = ./prometheus-client;
-          prometheus-proc = ./prometheus-proc;
-          prometheus-metrics-ghc = ./prometheus-metrics-ghc;
-          wai-middleware-prometheus = ./wai-middleware-prometheus;
-          prometheus-haskell-example = ./example;
-        };
-      };
-    };
+      flake.haskellFlakeProjectModules.output = { pkgs, lib, ... }: withSystem pkgs.system (ctx@{ config, ... }: {
+        source-overrides =
+          lib.mapAttrs (name: ks: ks.root)
+            config.haskellProjects.default.packages;
+      });
+    });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -5,18 +5,35 @@
     haskell-flake.url = "github:srid/haskell-flake";
   };
   outputs = inputs@{ self, nixpkgs, flake-parts, ... }:
-      systems = nixpkgs.lib.systems.flakeExposed;
     flake-parts.lib.mkFlake { inherit inputs; } ({ withSystem, ... }: {
+      systems = nixpkgs.lib.systems.flakeExposed;
       imports = [
         inputs.haskell-flake.flakeModule
       ];
       perSystem = { self', pkgs, ... }: {
         haskellProjects.default = { };
       };
-      flake.haskellFlakeProjectModules.output = { pkgs, lib, ... }: withSystem pkgs.system (ctx@{ config, ... }: {
-        source-overrides =
-          lib.mapAttrs (name: ks: ks.root)
-            config.haskellProjects.default.packages;
-      });
+      # TODO: Generalize and move to a new flake-parts module (or haskell-flake)
+      flake.haskellFlakeProjectModules = rec {
+        # Overlay consumed by this flake.
+        input = { pkgs, ... }: {
+          imports = [
+            # Flake input dependencies go here.
+          ];
+          # Haskell overrides go here.
+          overrides = self: super: { };
+        };
+        # Overlay exposed by this flake.
+        output = { pkgs, lib, ... }: withSystem pkgs.system (ctx@{ config, ... }: {
+          # Pass along the dependency overrides to consuming flake.
+          imports = [
+            input
+          ];
+          # Pass local packages, as overlay, to the consuming flake.
+          source-overrides =
+            lib.mapAttrs (name: ks: ks.root)
+              config.haskellProjects.default.packages;
+        });
+      };
     });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,26 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    haskell-flake.url = "github:srid/haskell-flake";
+  };
+  outputs = inputs@{ self, nixpkgs, flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = nixpkgs.lib.systems.flakeExposed;
+      imports = [
+        inputs.haskell-flake.flakeModule
+      ];
+      perSystem = { self', pkgs, ... }: {
+        haskellProjects.default = { };
+      };
+      flake.haskellFlakeProjectModules.output = { pkgs, ... }: {
+        source-overrides = {
+          prometheus-client = ./prometheus-client;
+          prometheus-proc = ./prometheus-proc;
+          prometheus-metrics-ghc = ./prometheus-metrics-ghc;
+          wai-middleware-prometheus = ./wai-middleware-prometheus;
+          prometheus-haskell-example = ./example;
+        };
+      };
+    };
+}

--- a/prometheus-proc/prometheus-proc.cabal
+++ b/prometheus-proc/prometheus-proc.cabal
@@ -17,7 +17,7 @@ source-repository head
 
 library
   exposed-modules:     Prometheus.Metric.Proc
-  build-depends:       base >=4.10 && <4.15
+  build-depends:       base >=4.10 && <5
                      , directory >= 1.2.5.0 && < 1.4
                      , filepath >=1.4 && <1.5
                      , prometheus-client >= 1.0.0 && < 1.1


### PR DESCRIPTION
[An internal project uses the `more-proc-metrics` branch (is it like staging branch?), and therefore this PR is based against that branch]

- Add `flake.nix` based on `haskell-flake`
  - Also expose the overlay via `haskellFlakeProjectModules`, so the consuming repo can use it directly.
- Uses GHC 9.2 (the default in current nixpkgs-unstable that we use)
  - The base version of prometheus-proc was changed to be consistent with other packages (and to work with GHC 9.2)
- Nothing done about HLS support; that can be done as a separate PR though.